### PR TITLE
Added xheight and capheight in face.Metrics()

### DIFF
--- a/truetype/face.go
+++ b/truetype/face.go
@@ -285,9 +285,11 @@ func (a *face) Metrics() font.Metrics {
 	scale := float64(a.scale)
 	fupe := float64(a.f.FUnitsPerEm())
 	return font.Metrics{
-		Height:  fixed.Int26_6(math.Ceil(scale * float64(a.f.ascent-a.f.descent+a.f.lineGap) / fupe)),
-		Ascent:  fixed.Int26_6(math.Ceil(scale * float64(+a.f.ascent) / fupe)),
-		Descent: fixed.Int26_6(math.Ceil(scale * float64(-a.f.descent) / fupe)),
+		Height:    fixed.Int26_6(math.Ceil(scale * float64(a.f.ascent-a.f.descent+a.f.lineGap) / fupe)),
+		Ascent:    fixed.Int26_6(math.Ceil(scale * float64(+a.f.ascent) / fupe)),
+		CapHeight: fixed.Int26_6(math.Ceil(scale * float64(a.f.capHeight) / fupe)),
+		Descent:   fixed.Int26_6(math.Ceil(scale * float64(-a.f.descent) / fupe)),
+		XHeight:   fixed.Int26_6(math.Ceil(scale * float64(a.f.xHeight) / fupe)),
 		// TODO: Metrics should include LineGap as a separate measure
 		// TODO: Would also be great to include Ex as in the height of an "x" --
 		// used widely for layout

--- a/truetype/truetype.go
+++ b/truetype/truetype.go
@@ -197,6 +197,8 @@ type Font struct {
 	ascent                  int32               // In FUnits.
 	descent                 int32               // In FUnits; typically negative.
 	lineGap                 int32               // In FUnits.
+	xHeight                 int32               // In FUnits.
+	capHeight               int32               // In FUnits.
 	bounds                  fixed.Rectangle26_6 // In FUnits.
 	// Values from the maxp section.
 	maxTwilightPoints, maxStorage, maxFunctionDefs, maxStackElements uint16
@@ -376,6 +378,15 @@ func (f *Font) parseMaxp() error {
 	f.maxStorage = u16(f.maxp, 18)
 	f.maxFunctionDefs = u16(f.maxp, 20)
 	f.maxStackElements = u16(f.maxp, 24)
+	return nil
+}
+
+func (f *Font) parseOS2() error {
+	if len(f.os2) < 90 {
+		return nil
+	}
+	f.xHeight = int32(int16(u16(f.os2, 86)))
+	f.capHeight = int32(int16(u16(f.os2, 88)))
 	return nil
 }
 
@@ -669,6 +680,9 @@ func parse(ttf []byte, offset int) (font *Font, err error) {
 		return
 	}
 	if err = f.parseHhea(); err != nil {
+		return
+	}
+	if err = f.parseOS2(); err != nil {
 		return
 	}
 	font = f


### PR DESCRIPTION
`xHeight` and `capHeight` are optionnal fields in the `OS/2` table.

This PR parses those fields and returns their values in the `face.Metrics()` method.